### PR TITLE
Truncate the msg down to `2500` 

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -91,10 +91,11 @@ const process = async ({
   }
 
   if (typeof msg === 'string') {
-    payload.text = msg
+    const text = msg.length <= 2500? msg : `${msg.substring(0, 2500)}...`;
+    payload.text = text
     payload.blocks.push({
       type: 'section',
-      text: { type: 'mrkdwn', text: `\`\`\`${msg}\`\`\`` }
+      text: { type: 'mrkdwn', text: `\`\`\`${text}\`\`\`` }
     })
   }
 


### PR DESCRIPTION
...to avoid `invalid_blocks` error from Slack